### PR TITLE
sb_fota: do not include sample directory in the repo root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,5 +6,4 @@
 
 zephyr_include_directories(include)
 
-add_subdirectory(sample)
 add_subdirectory(lib)

--- a/west.yml
+++ b/west.yml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 manifest:
-  self:
-    west-commands: scripts/west-commands.yml
+  # self:
+  #   west-commands: scripts/west-commands.yml
 
   remotes:
     - name: ncs


### PR DESCRIPTION
This will attempt to build the sample whenever the repository is imported. The sample is to be built as its own project in the dedicated directory. Remove west-commands from the manifest, we do not provide custom commands.